### PR TITLE
Bugfix in sql-workbench-dev 125.5

### DIFF
--- a/bucket/sql-workbench-dev.json
+++ b/bucket/sql-workbench-dev.json
@@ -12,7 +12,7 @@
         "64bit": {
             "bin": [
                 [
-                    "sqlwbconsole64.exe",
+                    "sqlwbconsole.cmd",
                     "sqlwbconsole"
                 ]
             ],
@@ -26,7 +26,7 @@
         "32bit": {
             "bin": [
                 [
-                    "sqlwbconsole.exe",
+                    "sqlwbconsole.cmd",
                     "sqlwbconsole"
                 ]
             ],


### PR DESCRIPTION
sqlwbconsole64.exe and sqlwbconsole.exe don't exist in version 125.5. Shims updated to link to sqlwbconsole.cmd.